### PR TITLE
Update PRONTO submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "pronto"]
 	path = pronto
-	url = https://github.com/prontocms/core.git
+	url = https://github.com/RasshoferLtd/pronto-core.git


### PR DESCRIPTION
The core repository of PRONTO was moved to a new organization recently. This PR updates the submodule URL.
