### PR TITLE
Add article guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Well, that’s easy! First, head over to our [GitHub](https://github.com/fapprik
 
 ## Writing articles
 
-If you find out that there’s no article on a specific topic you are currently into, but there should be one, go ahead and write about it! Here are some guidelines for you to keep in mind. Note that we use these guidelines to review your article and will give you hints in the PR chat on what's missing.
+If you find out that there’s no article on a specific topic you are currently into, but there should be one, go ahead and write about it! Here are some guidelines for you to keep in mind. Note that we use these guidelines to review your article and will give you hints in the PR chat on what’s missing.
 
 While JS-Tricks.com itself is released under the MIT license, all articles are published under [CC-BY-SA 3.0](http://creativecommons.org/licenses/by-sa/3.0/).
 
@@ -44,7 +44,7 @@ While JS-Tricks.com itself is released under the MIT license, all articles are p
 
 * **The PRONTO style.** If you’ve never worked with PRONTO before, check out their [»Managing content« section](http://prontocms.com/docs/managing-content) in order to get started.
 
-* **Markdown format.** If that's new for you, PRONTO provides a [short introduction](http://prontocms.com/docs/formatting-text) on that. There's also a short [writing](https://help.github.com/articles/markdown-basics/) by the GitHub staff. For correct syntax highlighting, please use the [GitHub style](https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting). On JS-Tricks.com you may use `javascript`, `css` and `html`.
+* **Markdown format.** If that’s new for you, PRONTO provides a [short introduction](http://prontocms.com/docs/formatting-text) on that. There’s also a [short writing](https://help.github.com/articles/markdown-basics/) by the GitHub staff. For correct syntax highlighting, please use the [GitHub style](https://help.github.com/articles/github-flavored-markdown/#syntax-highlighting). On JS-Tricks.com you may use `javascript`, `css` and `html`.
 
 ### Guidelines
 
@@ -58,7 +58,7 @@ While JS-Tricks.com itself is released under the MIT license, all articles are p
 
 * **If you want, you may add your name to the contributors list.** Feel free to add your GitHub username to the `Contributors` field (comma-separated list) in your `post.md` to be listed on the site’s [contributors list](http://js-tricks.com/contributors).
 
-* **When it's online: spread the word!**
+* **When it’s online: spread the word!**
 
 ## License
 


### PR DESCRIPTION
I started to write some guidelines on how people should create articles. These should also form the building blocks on how we will review new writings. Moreover I don't think that the MIT license fits well in the context of articles, which should be published using something like [CC-BY-SA 3.0](http://creativecommons.org/licenses/by-sa/3.0/).

@rasshofer Comments please.
