### PR TITLE
Implement missing Markdown styles

### DIFF
--- a/source/styles/main.scss
+++ b/source/styles/main.scss
@@ -55,7 +55,7 @@ h2 a:hover, h3 a:hover {
   text-decoration: none;
 }
 
-p, pre {
+p, pre, ul, ol, hr {
   margin: 0 0 15px;
 }
 
@@ -72,8 +72,33 @@ a:link, a:hover, a:active, a:visited, a:focus {
   outline: none;
 }
 
-ul, ol, li {
-  list-style: none;
+ul {
+  list-style: square inside;
+}
+
+ol {
+  list-style: decimal inside;
+}
+
+blockquote p {
+    padding: 0 15px;
+    border-left: 3px solid #ccc;
+    font-style: italic;
+}
+
+hr {
+  width: 100%;
+  height: 1px;
+  background: #ccc;
+  border: 0;
+}
+
+strong {
+  font-weight: bold;
+}
+
+em {
+  font-style: italic;
 }
 
 .center {
@@ -209,7 +234,7 @@ nav .center {
   text-align: center;
 }
 
-.center p:last-child, .center pre:last-child {
+.center > :last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION
Implements the following Markdown styles missing so far…
- Bold text
- Italic text
- Unordered lists
- Ordered lists
- Horizontal rules
- Quotes

---

![](https://picpig.com/u6hxy8ec6u.png)
