### PR TITLE
Removed falsely inserted return statement

### DIFF
--- a/content/10-dont-use-fat-arrows-in-coffeescript-just-because-of-this/post.md
+++ b/content/10-dont-use-fat-arrows-in-coffeescript-just-because-of-this/post.md
@@ -38,18 +38,19 @@ A = (function() {
   function A() {
     this.funcB = __bind(this.funcB, this);
     this.funcA();
-    return this.funcB();
+    this.funcB();
   }
 
   A.prototype.funcA = function() {
     return 'funcA';
   };
-  
+
   A.prototype.funcB = function() {
     return 'funcB';
   };
 
   return A;
+
 })();
 
 a = new A;
@@ -80,7 +81,7 @@ a = new A
 
 This will break because `funcA` is implemented with `->` and the function is called in the context of `map`, where `@name` won’t be defined. By using `=>`, it doesn’t matter where and how to call the method as its context is permanently bound to the object:
 
-```js
+```coffeescript
 class A
 
     constructor: () ->


### PR DESCRIPTION
The constructor function A is transpiled by the coffee compiler, there shouldn`t be a return statement before the function 'funcB'. I also removed the wrong codeblock description and added the right one.

cheers!
